### PR TITLE
Use non-free redis plan so stunnel works

### DIFF
--- a/app.json
+++ b/app.json
@@ -20,7 +20,7 @@
   },
   "addons": [
     "heroku-postgresql",
-    "heroku-redis"
+    { "plan": "heroku-redis:premium-0" }
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
stunnel is not configured on the redis db with the hobby dev heroku redis plan.  this PR specifies the cheapest non-free plan to be used.  this allows review apps to work.  without this, review apps would use the hobby-dev plan.  app.json schema found here: https://devcenter.heroku.com/articles/app-json-schema
