### PR TITLE
Allow only one Spotify auth at a time, which includes...

### DIFF
--- a/bin/controllers/playlist.js
+++ b/bin/controllers/playlist.js
@@ -15,22 +15,17 @@ class PlaylistController {
   }
 
   routes() {
-    this.router.get('/:playlistId', this._getPlaylist.bind(this))
-    this.router.get('/', this._get.bind(this))
+    this.router.get('/', this._getPlaylist.bind(this))
 
     return this.router
   }
 
-  _get(req, res) {
-    res.send('hello world')
-  }
-
   _getPlaylist(req, res) {
 
-    this.db.Account.findOne({ where: { id: req.session.spotifyId } })
+    this.db.Account.findOne({ })
       .then(function(acct) {
         const opts = { auth: { 'bearer': acct.get('access_token') } }
-        const playlistUrl = 'https://api.spotify.com/v1/users/' + acct.get('id') + '/playlists/' + req.params.playlistId
+        const playlistUrl = 'https://api.spotify.com/v1/users/' + acct.get('id') + '/playlists/' + acct.get('playlist_id')
 
         request.get(playlistUrl, opts, function(error, response, body) {
           const playlist = JSON.parse(body)
@@ -40,32 +35,6 @@ class PlaylistController {
           res.json(playlist)
         })
       })
-
-    // let opts = {
-    //   where: { key: req.params.accountKey },
-    //   include: [{
-    //     model: this.db.Playlist,
-    //     where: { active: true },
-    //     include: [{ model: this.db.Track }]
-    //   }]
-    // }
-    //
-    // this.db.Account.findOne(opts).call('toJSON').then(function(account) {
-    //   let playlist = account.Playlists[0]
-    //
-    //   playlist.tracks = _.reduce(playlist.Tracks, function(m, t) {
-    //     m.push(_.omit(t, _.isNull))
-    //
-    //     delete t.PlaylistTracks
-    //     return m
-    //   }, [])
-    //
-    //   delete playlist.Tracks
-    //
-    //   res.json(playlist)
-    // }).catch(function(err) {
-    //   res.status(204).end();
-    // })
   }
 
 }

--- a/bin/controllers/sms.js
+++ b/bin/controllers/sms.js
@@ -22,8 +22,8 @@ class SmsController {
   }
 
   _post(req, res) {
-    let opts = { where: { number: req.body.To } }
-    db.Account.findOne(opts).then(function(acct) {
+    db.Account.findOne({ })
+    .then(function(acct) {
       if (!acct) {
         let err = new Error(`No account found, have you auth'd with Spotify?`)
         fmt.log({ type: 'warning', msg: err })

--- a/src/actions/accountActions.js
+++ b/src/actions/accountActions.js
@@ -1,4 +1,7 @@
+import axios from 'axios'
+
 export function login(data) {
+  localStorage.setItem('account', JSON.stringify(data))
   return {
     type: 'ACCOUNT_LOGGED_IN',
     payload: data
@@ -6,7 +9,15 @@ export function login(data) {
 }
 
 export function logout() {
-  return {
-    type: 'ACCOUNT_LOGGED_OUT'
+  localStorage.removeItem('account')
+  return function(dispatch) {
+    dispatch({type: 'BEGIN_LOGOUT'})
+    return axios.get('/api/auth/logout')
+      .then((response) => {
+        dispatch({type: 'LOGOUT_FULFILLED'})
+      })
+      .catch((err) => {
+        dispatch({type: 'LOGOUT_REJECTED', payload: err})
+      })
   }
 }

--- a/src/actions/musicActions.js
+++ b/src/actions/musicActions.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
 
-export function fetchPlaylist(id) {
+export function fetchPlaylist() {
   return function(dispatch) {
     dispatch({type: 'FETCH_PLAYLIST'})
-    return axios.get('/api/playlist/' + id)
+    return axios.get('/api/playlist')
       .then((response) => {
         dispatch({type: 'FETCH_PLAYLIST_FULFILLED', payload: response.data})
       })

--- a/src/components/Logout.js
+++ b/src/components/Logout.js
@@ -1,0 +1,35 @@
+let _ = require('lodash')
+
+import { Component } from 'react'
+import { routerActions } from 'react-router-redux'
+import { connect } from 'react-redux'
+
+import { logout } from '../actions/accountActions'
+
+function select(store, ownProps) {
+  const redirectToLogin = '/'
+  const account = store.account.account
+  return {
+    redirectToLogin,
+    account
+  }
+}
+
+class Logout extends Component {
+  componentWillReceiveProps(nextProps) {
+    const { replace, redirectToLogin, account } = nextProps
+    const { account: previousAccount } = this.props
+
+    if (!_.isEmpty(previousAccount) && _.isEmpty(account)) {
+      replace(redirectToLogin)
+    }
+  }
+
+  render() {
+    this.props.logout()
+
+    return null
+  }
+}
+
+export default connect(select, { logout, replace: routerActions.replace })(Logout);

--- a/src/components/Music.js
+++ b/src/components/Music.js
@@ -30,8 +30,8 @@ class Music extends Component {
     // TODO: replace hard-coded playlist with create or use existing playlist option:
     //  - select existing playlist from list
     //  - create new playlist
-    this.props.fetchPlaylist('1WCoOeyBzRcWQfcFaJObFZ')
-    this.timer = setInterval(() => this.props.fetchPlaylist('1WCoOeyBzRcWQfcFaJObFZ'), 5000)
+    this.props.fetchPlaylist()
+    this.timer = setInterval(() => this.props.fetchPlaylist(), 5000)
   }
 
   componentWillUnmount() {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import App from './components/App';
 import Music from './components/Music';
 import Auth from './components/Auth';
 import Thanks from './components/Thanks';
+import Logout from './components/Logout';
 import store from './store'
 
 
@@ -31,6 +32,7 @@ ReactDOM.render(
       <Route path="/auth" component={Auth}/>
       <Route path="/music" component={UserIsAuthenticated(Music)}/>
       <Route path="/thanks" component={Thanks}/>
+      <Route path="/logout" component={Logout}/>
       <Route path="*" component={NoMatch}/>
     </Router>
   </Provider>,

--- a/src/reducers/accountReducer.js
+++ b/src/reducers/accountReducer.js
@@ -1,5 +1,5 @@
 export default function reducer(state={
-  account: {},
+  account: JSON.parse(localStorage.getItem('account')) || {},
   fetching: false,
   fetched: false,
   error: null
@@ -18,8 +18,11 @@ export default function reducer(state={
     case 'ACCOUNT_LOGGED_IN': {
       return {...state, account: action.payload}
     }
-    case 'ACCOUNT_LOGGED_OUT': {
+    case 'LOGOUT_FULFILLED': {
       return {...state, fetched: false, account: {}}
+    }
+    case 'LOGOUT_REJECTED': {
+      return state
     }
     default: {
       return state;


### PR DESCRIPTION
- Ability to logout via manual entry of /#/logout route
- When logged in (i.e. someone has OAuth-d with Spotiy), other visitors will not see Spotify OAuth request
- Login is persisted in browser localStorage
