### PR TITLE
Add Salesforce account details to setup

### DIFF
--- a/bin/controllers/auth.js
+++ b/bin/controllers/auth.js
@@ -45,7 +45,9 @@ class AuthController {
           `&name=${encodeURIComponent(acct.get('display_name'))}` +
           `&displayNumber=${encodeURIComponent(acct.get('display_number'))}` +
           `&roomName=${encodeURIComponent(acct.get('travolta_room_name'))}` +
-          `&orgName=${encodeURIComponent(acct.get('salesforce_org'))}`
+          `&orgName=${encodeURIComponent(acct.get('salesforce_org'))}` +
+          `&salesforceUserName=${encodeURIComponent(acct.get('salesforce_user_name'))}` +
+          `&salesforceUserEmail=${encodeURIComponent(acct.get('salesforce_user_email'))}`
         )
       } else {
 
@@ -113,14 +115,18 @@ class AuthController {
                     travolta_room_name: body.room_name,
                     salesforce_org: body.salesforce_org,
                     number: body.phone_number,
-                    display_number: body.display_phone_number
+                    display_number: body.display_phone_number,
+                    salesforce_user_name: body.salesforce_user_name,
+                    salesforce_user_email: body.salesforce_user_email
                   })
                   .then(function() {
                     // Set session information
-                    req.session.spotifyId       = account.get('id');
-                    req.session.smsNumber       = account.get('number');
-                    req.session.display_number  = account.get('display_number');
-                    req.session.display_name    = account.get('display_name');
+                    req.session.spotifyId             = account.get('id');
+                    req.session.smsNumber             = account.get('number');
+                    req.session.display_number        = account.get('display_number');
+                    req.session.display_name          = account.get('display_name');
+                    req.session.salesforce_user_name  = account.get('salesforce_user_name');
+                    req.session.salesforce_user_email = account.get('salesforce_user_email');
                     req.session.save();
 
                     // Redirect to React auth route
@@ -130,6 +136,8 @@ class AuthController {
                       `&name=${encodeURIComponent(account.get('display_name'))}` +
                       `&displayNumber=${encodeURIComponent(account.get('display_number'))}` +
                       `&roomName=${encodeURIComponent(account.get('travolta_room_name'))}` +
+                      `&salesforceUserName=${encodeURIComponent(account.get('salesforce_user_name'))}` +
+                      `&salesforceUserEmail=${encodeURIComponent(account.get('salesforce_user_email'))}` +
                       `&orgName=${encodeURIComponent(account.get('salesforce_org'))}`
                     )
 
@@ -148,10 +156,12 @@ class AuthController {
 
                 } else { // if error registering with Travolta
                   // Set session information
-                  req.session.spotifyId       = account.get('id');
-                  req.session.smsNumber       = account.get('number');
-                  req.session.display_number  = account.get('display_number');
-                  req.session.display_name    = account.get('display_name');
+                  req.session.spotifyId             = account.get('id');
+                  req.session.smsNumber             = account.get('number');
+                  req.session.display_number        = account.get('display_number');
+                  req.session.display_name          = account.get('display_name');
+                  req.session.salesforce_user_name  = account.get('salesforce_user_name');
+                  req.session.salesforce_user_email = account.get('salesforce_user_email');
                   req.session.save();
 
                   // Redirect to React auth route
@@ -161,6 +171,8 @@ class AuthController {
                     `&name=${encodeURIComponent(account.get('display_name'))}` +
                     `&displayNumber=${encodeURIComponent(account.get('display_number'))}` +
                     `&roomName=${encodeURIComponent(account.get('travolta_room_name'))}` +
+                    `&salesforceUserName=${encodeURIComponent(account.get('salesforce_user_name'))}` +
+                    `&salesforceUserEmail=${encodeURIComponent(account.get('salesforce_user_email'))}` +
                     `&orgName=${encodeURIComponent(account.get('salesforce_org'))}`
                   )
 

--- a/bin/controllers/setup.js
+++ b/bin/controllers/setup.js
@@ -69,6 +69,8 @@ class SetupController {
           res.json({
             number: acct.get('number'),
             displayNumber: acct.get('display_number'),
+            salesforceUserName: acct.get('salesforce_user_name'),
+            salesforceUserEmail: acct.get('salesforce_user_email'),
             playlistId: `spotify:user:${acct.get('id')}:playlist:${acct.get('playlist_id')}`,
             playlistPrependTextV1: `spotify:user:${acct.get('id')}:playlist:${acct.get('playlist_id')}`,
             playlistPrependTextV2: `https://play.spotify.com/user/${acct.get('id')}/playlist/${acct.get('playlist_id')}`

--- a/bin/controllers/setup.js
+++ b/bin/controllers/setup.js
@@ -28,6 +28,8 @@ class SetupController {
     .then(function(acct) {
       res.json({
         number: acct.get('number'),
+        salesforceUserName: acct.get('salesforce_user_name'),
+        salesforceUserEmail: acct.get('salesforce_user_email'),
         displayNumber: acct.get('display_number'),
         playlistId: `spotify:user:${acct.get('id')}:playlist:${acct.get('playlist_id')}`,
         playlistPrependTextV1: `spotify:user:${acct.get('id')}:playlist:1WCoOeyBzRcWQfcFaJObFZ`,

--- a/bin/models/account.js
+++ b/bin/models/account.js
@@ -23,6 +23,8 @@ module.exports = function(sequelize, DataTypes) {
 		travolta_token: DataTypes.STRING,
 		travolta_room_name: DataTypes.STRING,
 		salesforce_org: DataTypes.STRING,
+		salesforce_user_name: DataTypes.STRING,
+		salesforce_user_email: DataTypes.STRING,
 		oauth_token: DataTypes.JSON
 	})
 }

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -24,7 +24,8 @@ class Setup extends Component {
   render() {
     return (
       <div className="setup">
-        <h1>Verify or input the following values</h1>
+        <h1>You are { this.props.setup.salesforce_user_name }, login to Salesforce with { this.props.setup.salesforce_user_email }
+        <h2>Verify or input the following values</h2>
         <br/>
         <div className="input-element">
           <span>Playlist URI: </span>

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -24,7 +24,7 @@ class Setup extends Component {
   render() {
     return (
       <div className="setup">
-        <h1>You are { this.props.setup.salesforce_user_name }, login to Salesforce with { this.props.setup.salesforce_user_email }</h1>
+        <h1>You are { this.props.setup.salesforceUserName }, login to Salesforce with { this.props.setup.salesforceUserEmail }</h1>
         <h2>Verify or input the following values</h2>
         <br/>
         <div className="input-element">

--- a/src/components/Setup.js
+++ b/src/components/Setup.js
@@ -24,7 +24,7 @@ class Setup extends Component {
   render() {
     return (
       <div className="setup">
-        <h1>You are { this.props.setup.salesforce_user_name }, login to Salesforce with { this.props.setup.salesforce_user_email }
+        <h1>You are { this.props.setup.salesforce_user_name }, login to Salesforce with { this.props.setup.salesforce_user_email }</h1>
         <h2>Verify or input the following values</h2>
         <br/>
         <div className="input-element">


### PR DESCRIPTION
This adds the Salesforce account email and name to the setup page
so demoers know which user's Chatter posts will end up on their
particular Dreamhouse Disco instance.
